### PR TITLE
Add more concistency settings naming and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terralego Backend for OPP module
 
 ### Requirements
 
-* To handle pictures in templates, please install weasyprint requirement librairies 
+* To handle pictures in templates, please install weasyprint requirement librairies
 https://weasyprint.readthedocs.io/en/stable/install.html#linux
 
 ### First, create a data layer for observatory
@@ -21,6 +21,8 @@ Then get the given primary key, for example 10.
 
 ```python
 TROPP_OBSERVATORY_LAYER_PK=10  # replace by primary key given by command
+
+TROPP_OBSERVATORY_ID = 20 # set the nationnal id of your observatory
 
 VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
   'terra_opp': [
@@ -39,7 +41,7 @@ AUTH_USER_MODEL = 'terra_accounts.TerraUser'
 If your project is not using the default django storage, then you must define and set a url fetcher in order to tell weasyprint where to find your media files.
 
 An example of url fetcher using media files from S3 storage :
- 
+
  ```python
 from django.conf import settings
 from terra_opp.renderers import django_url_fetcher

--- a/terra_opp/checks.py
+++ b/terra_opp/checks.py
@@ -45,6 +45,25 @@ def check_dedicated_layer(app_configs, **kwargs):
 
 
 @register()
+def check_opp_id_defined(app_configs, **kwargs):
+    errors = []
+    tropp_observatory_id = settings.TROPP_OBSERVATORY_ID
+    if not tropp_observatory_id:
+        errors.append(
+            Warning(
+                "To correctly use OPP you should set TROPP_OBSERVATORY_ID and restart your instance as soon as possible.",
+                hint="""
+                    TROPP_OBSERVATORY_ID is the identifier of your observatory at national level
+                    Ex: TROPP_OBSERVATORY_ID = 20
+                """,
+                obj=None,
+                id="terra_opp.E004",
+            )
+        )
+    return errors
+
+
+@register()
 def check_installed_apps(app_configs, **kwargs):
     errors = []
     if "versatileimagefield" not in settings.INSTALLED_APPS:

--- a/terra_opp/models.py
+++ b/terra_opp/models.py
@@ -200,7 +200,7 @@ class Picture(BaseUpdatableModel):
 
     @property
     def identifier(self):
-        obs_id = settings.OBSERVATORY_ID
+        obs_id = settings.TROPP_OBSERVATORY_ID
         pic_index = list(
             self.viewpoint.ordered_pics_by_date.values_list("id", flat=True)
         ).index(self.id)

--- a/terra_opp/settings.py
+++ b/terra_opp/settings.py
@@ -36,4 +36,4 @@ TROPP_SEARCHABLE_PROPERTIES = {
 
 # Create a geostore layer and provide its Primary Key here
 TROPP_OBSERVATORY_LAYER_PK = None
-OBSERVATORY_ID = None
+TROPP_OBSERVATORY_ID = None

--- a/terra_opp/tests/test_viewpoints.py
+++ b/terra_opp/tests/test_viewpoints.py
@@ -25,7 +25,7 @@ from terra_opp.tests.factories import (
 from terra_opp.tests.mixins import TestPermissionsMixin
 
 
-@override_settings(OBSERVATORY_ID=20)
+@override_settings(TROPP_OBSERVATORY_ID=20)
 class ViewpointTestCase(APITestCase, TestPermissionsMixin):
     @classmethod
     @override_settings(TROPP_PICTURES_STATES_WORKFLOW=True)


### PR DESCRIPTION
* Rename `OBSERVATORY_ID` to `TROPP_OBSERVATORY_ID` to match other settings naming convention
* Raise a warning if `TROPP_OBSERVATORY_ID` is not set like other *TROPP* settings
* Update readme accordingly to newer changes